### PR TITLE
fix postMessage in nested iframe

### DIFF
--- a/public/script/ViewBridge.js
+++ b/public/script/ViewBridge.js
@@ -50,7 +50,7 @@ var _typeof2 = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator
         command: t,
         ext: i
       };
-      o.comefrom = "webframe", o.webviewID = f.webviewID, o = JSON.parse(JSON.stringify(o)), window.top.postMessage(o, "*")
+      o.comefrom = "webframe", o.webviewID = f.webviewID, o = JSON.parse(JSON.stringify(o)), window.parent.postMessage(o, "*")
     }
 
     function r(e) {
@@ -331,7 +331,7 @@ var _typeof2 = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator
         command: n,
         ext: i
       };
-      o = JSON.parse(JSON.stringify(o)), window.top.postMessage(o, "*")
+      o = JSON.parse(JSON.stringify(o)), window.parent.postMessage(o, "*")
     }
 
     function i() {

--- a/public/script/bridge.js
+++ b/public/script/bridge.js
@@ -23,7 +23,7 @@ var _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator 
     for (var o in n)("object" === ("undefined" == typeof exports ? "undefined" : _typeof(exports)) ? exports : e)[o] = n[o]
   }
 }(void 0, function() {
-  var storage = window.top.__storage
+  var storage = window.parent.__storage
 
   function toResult(msg, data, command) {
     let obj = {
@@ -215,7 +215,7 @@ var _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator 
       },
       v = function(e) {
         var t = JSON.parse(JSON.stringify(e));
-        t.to = "backgroundjs", t.comefrom = "webframe", t.command = "COMMAND_FROM_ASJS", t.appid = s, t.appname = a, t.apphash = i, t.webviewID = f, window.top.postMessage(t, "*")
+        t.to = "backgroundjs", t.comefrom = "webframe", t.command = "COMMAND_FROM_ASJS", t.appid = s, t.appname = a, t.apphash = i, t.webviewID = f, window.parent.postMessage(t, "*")
       },
       g = function(e) {
         e.command = "COMMAND_FROM_ASJS", e.appid = s, e.appname = a, e.apphash = i, e.webviewID = f;
@@ -258,7 +258,7 @@ var _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator 
       };
     window._____sendMsgToNW = v;
     var h = function(e) {
-        e.to = "contentscript", e.comefrom = "webframe", e.webviewID = f, window.top.postMessage(e, "*")
+        e.to = "contentscript", e.comefrom = "webframe", e.webviewID = f, window.parent.postMessage(e, "*")
       },
       _ = function(e, t, n) {
         var o = /Sync$/.test(e),


### PR DESCRIPTION
**问题描述**：

当微信小程序运行在iframe中时，无法加载。

**重现步骤**:

1.创建一个任意微信小程序项目。

2.在项目根目录创建一个index.html文件， 内容如下：

```

<header>
	<title>WXMLView</title>
    <meta name="viewport" content="width=device-width, height=device-height,user-scalable=no, initial-scale=1.0" />
	<style>
		#content {
			width: 100%;
			height: 100%;
		}
	</style>
</header>
<body>
	<iframe id="content" src="./"/>
</body>

```

3.在项目目录下使用wept启动服务器，访问http://localhost:3000/index.html

**错误截图**:

![gif](https://cloud.githubusercontent.com/assets/7069719/19503159/5324d014-95e4-11e6-9abf-742aeaba6d34.gif)


**原因分析**:

`window.top` 在这种情况下获取的是最顶层窗口对象，而不是微信小程序的窗口对象。


