### PR TITLE
Fix wcsc and wcc compile error when execFile path contains spaces

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,14 +1,14 @@
 const fs = require('fs')
 const path = require('path')
-const exec = require('child_process').exec
+const execFile = require('child_process').execFile
 const cache = require('./cache')
 const config = require('./config')
 const isWin = /^win/.test(process.platform)
 const wcsc = path.resolve(__dirname, '../bin/wcsc' + (isWin ? '.exe' : ''))
 const wcc = path.resolve(__dirname, '../bin/wcc' + (isWin ? '.exe' : ''))
 const util = require('./util')
-const wxml_cmd = `${wcc} -d `
-const wxss_cmd = `${wcsc} -lc `
+const wxml_args = ['-d']
+const wxss_args = ['-lc']
 const babel = require('babel-core')
 const convert = require('convert-source-map')
 
@@ -32,8 +32,7 @@ module.exports = function (full_path) {
     if (/\.wxml$/.test(full_path)) {
       parseImports(full_path, (err, srcs) => {
         if (err) return reject(err)
-        let args = srcs.join(' ')
-        exec(`${wxml_cmd}${args}`, (err, stdout, stderr) => {
+        execFile(wcc, wxml_args.concat(srcs), (err, stdout, stderr) => {
           if (err) {
             console.error(err.stack)
             return reject(new Error(`${full_path} 编译失败，请检查`))
@@ -44,7 +43,7 @@ module.exports = function (full_path) {
         })
       })
     } else if (/\.wxss$/.test(full_path)) {
-      exec(`${wxss_cmd}${full_path}`, (err, stdout, stderr) => {
+      execFile(wcsc, wxss_args.concat(full_path), (err, stdout, stderr) => {
         if (err) {
           console.error(err.stack)
           return reject(new Error(`${full_path} 编译失败，请检查`))


### PR DESCRIPTION
当wept不是作为全局模块被安装到了包含空格的路径时，启动wept， wxml和wcss会编译失败