### PR TITLE
let => var

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,7 +1,7 @@
 var webpack = require('webpack')
 var config = require('./webpack.config')
 
-let plugins = config.plugins = []
+var plugins = config.plugins = []
 
 config.devtool = 'hidden-source-map'
 


### PR DESCRIPTION
Node版本 5.10.1 使用webpack会报错

```
let plugins = config.plugins = []                                                                              
^^^                                                                                                            
                                                                                                               
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode     
    at exports.runInThisContext (vm.js:53:16)                                                                  
    at Module._compile (module.js:387:25)       
```                                                               
