### PR TITLE
Fix couldn't find preset 'babel-preset-es2015'

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -123,7 +123,7 @@ exports.parseJavascript = function (config, full_path) {
   return new Promise(function (resolve, reject) {
     let isModule = full_path != 'app.js' && config.pages.indexOf(full_path.replace(/\.js$/, '')) == -1
     babel.transformFile(full_path, {
-      presets: [path.resolve(__dirname, '../node_modules/babel-preset-es2015')],
+      presets: ['babel-preset-es2015'].map(require.resolve),
       sourceMaps: true,
       sourceRoot: process.cwd(),
       sourceFileName: full_path,


### PR DESCRIPTION
**如何重现**:

由于我们的模块引用了wept，执行 npm install 后，会得到如下目录结构

```
.
├── package.json
├── node_modules
   ├── babel-preset-es2015
   └── wept
```

由于npm的新的安装机制， wept所依赖的模块例如这个babel-preset-es2015会被安装到与wept同级的目录。所以之前 `path.resolve(__dirname, '../node_modules/babel-preset-es2015')` 这种写法是错误的。

我从这个地方找到了解决办法
https://github.com/babel/gulp-babel/issues/93





