### PR TITLE
添加自定义代理头部和url代理参数

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -7,10 +7,10 @@ const tunnel = require('tunnel')
 const config = require('./config')
 
 module.exports = function* (context) {
-  let url = context.request.header['x-remote']
+  let url = context.request.header['x-remote'] || context.request.query.url
   if (!url) throw new Error('header X-Remote required')
-  let headers = assign({}, context.header)
   let conf = yield config()
+  let headers = assign({}, context.header, conf.headers)
   delete headers['x-remote']
   delete headers['host']
   let urlObj = parseUrl(url)
@@ -34,7 +34,6 @@ module.exports = function* (context) {
     let proxyMethod = isHttps ? 'httpsOverHttp' : 'httpOverHttp'
     opt.agent = tunnel[proxyMethod]({proxy: conf.proxy})
   }
-
   let req = requestClient.request(opt)
   let res = yield pipeRequest(context.req, req)
   for (var name in res.headers) {


### PR DESCRIPTION
这样可以在演示时，可以通过对图片链接增加代理
```js

 function proxyImage(src) {
  if (__wxConfig.proxyImage && typeof src === 'string') {
    console.log('proxy')
    return `/remoteProxy?url=${encodeURIComponent(src)}`
  }
  return src
}

let imgUrl = proxyImage(imgUrl)
```
 避免 某些图片cdn referer 的限制