### PR TITLE
fix loadJavascript babel config

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -185,7 +185,22 @@ exports.parseJavascript = function(config, full_path) {
 function loadJavascript(full_path, useBabel, cb) {
   if (useBabel) {
     babel.transformFile(full_path, {
-      presets: ['babel-preset-es2015'].map(require.resolve),
+      presets: [
+        [
+          'es2015',
+          {
+            loose: true,
+            modules: false,
+          },
+        ],
+        [
+          'env',
+          {
+            loose: true,
+            modules: false,
+          },
+        ],
+      ],
       sourceMaps: true,
       sourceFileName: full_path,
       babelrc: false,


### PR DESCRIPTION
when import `lodash`, this error will happen  
![image](https://user-images.githubusercontent.com/28128450/53295785-d76e4780-383d-11e9-80a2-552405658dce.png)



error detail: 
![image](https://user-images.githubusercontent.com/28128450/53295788-e3f2a000-383d-11e9-9a60-6476c47a4f67.png),
 comparing to `lodash` source code, the `context`(here is `to`) was `{}`

In miniprogram all things right, so I just copy the babel's config to wept.

The original presets `presets: ['babel-preset-es2015'].map(require.resolve)` may should be `module: false`?